### PR TITLE
Simple Value Support

### DIFF
--- a/ciborium/src/value/de.rs
+++ b/ciborium/src/value/de.rs
@@ -63,7 +63,6 @@ impl<'de> serde::de::Visitor<'de> for Visitor {
 
     mkvisit! {
         visit_bool(bool),
-        visit_simple(u8),
         visit_f32(f32),
         visit_f64(f64),
 
@@ -237,7 +236,7 @@ impl<'a, 'de> de::Deserializer<'de> for Deserializer<&'a Value> {
             Value::Map(x) => visitor.visit_map(Deserializer(x.iter().peekable())),
             Value::Bool(x) => visitor.visit_bool(*x),
             Value::Null => visitor.visit_none(),
-            Value::Simple(x) => visitor.visit_simple(*x),
+            Value::Simple(x) => visitor.visit_u8(*x),
 
             Value::Tag(t, v) => {
                 let parent: Deserializer<&Value> = Deserializer(v);

--- a/ciborium/src/value/ser.rs
+++ b/ciborium/src/value/ser.rs
@@ -12,7 +12,7 @@ impl ser::Serialize for Value {
         match self {
             Value::Bytes(x) => serializer.serialize_bytes(x),
             Value::Bool(x) => serializer.serialize_bool(*x),
-            Value::Simple(x) => serializer.serialize_simple(*x),
+            Value::Simple(x) => serializer.serialize_u8(*x),
             Value::Text(x) => serializer.serialize_str(x),
             Value::Null => serializer.serialize_unit(),
 
@@ -122,7 +122,6 @@ impl ser::Serializer for Serializer<()> {
 
     mkserialize! {
         serialize_bool(bool),
-        serialize_simple(u8),
 
         serialize_f32(f32),
         serialize_f64(f64),


### PR DESCRIPTION
Evtl. muss das so gelöst werden. Wie genau kann ich diese Version in cddl nutzen, damit ich das testen kann?

Ich habe jetzt die u8 Funktionen genutzt und die visit_simple wieder aus mkvisit usw. entfernt, da es nicht mit dem werde::Visitor trait funktioniert. 